### PR TITLE
Fix meal plan parsing: prevent meal descriptions from being added as …

### DIFF
--- a/client/src/components/GroceryListForm.js
+++ b/client/src/components/GroceryListForm.js
@@ -762,23 +762,43 @@ function GroceryListForm({
               setRecipes(aiData.recipes);
             }
             
-            // Use structured products
+            // Use structured products - filter out meal descriptions
             if (aiData.products && aiData.products.length > 0) {
-              const groceryItems = aiData.products.map(product => {
-                const quantity = product.quantity || '1';
-                const unit = product.unit ? ` ${product.unit}` : '';
+              console.log('🔍 Processing structured products, total count:', aiData.products.length);
+              
+              // Filter out any "products" that are actually meal descriptions
+              const realGroceryItems = aiData.products.filter(product => {
                 const name = product.productName || product.name;
-                return `• ${quantity}${unit} ${name}`;
+                const isMealDescription = name.match(/^(Breakfast|Lunch|Dinner|Snack):/i);
+                
+                if (isMealDescription) {
+                  console.log('🍽️ Skipping meal plan item (should be recipe):', name);
+                  return false;
+                }
+                return true;
               });
               
-              const groceryListText = groceryItems.join('\n');
-              setInputText(groceryListText);
+              console.log('🛒 Real grocery items after filtering:', realGroceryItems.length);
               
-              if (textareaRef.current) {
-                textareaRef.current.value = groceryListText;
+              if (realGroceryItems.length > 0) {
+                const groceryItems = realGroceryItems.map(product => {
+                  const quantity = product.quantity || '1';
+                  const unit = product.unit ? ` ${product.unit}` : '';
+                  const name = product.productName || product.name;
+                  return `• ${quantity}${unit} ${name}`;
+                });
+                
+                const groceryListText = groceryItems.join('\n');
+                setInputText(groceryListText);
+                
+                if (textareaRef.current) {
+                  textareaRef.current.value = groceryListText;
+                }
+                
+                groceryListProcessed = true;
+              } else {
+                console.log('⚠️ No real grocery items found after filtering meal descriptions');
               }
-              
-              groceryListProcessed = true;
             }
           }
           

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -506,6 +506,13 @@ IMPORTANT: Return ONLY the JSON object with specific, measurable items and quant
         const trimmed = line.trim();
         if (trimmed.match(/^[•\-*]\s*(.+)/) || trimmed.match(/^\d+\.?\s*(.+)/)) {
           const item = trimmed.replace(/^[•\-*\d\.]\s*/, '');
+          
+          // Skip meal plan descriptions in text fallback parsing
+          if (item.match(/^(Breakfast|Lunch|Dinner|Snack):/i)) {
+            console.log('🍽️ Skipping meal plan item in text fallback:', item);
+            return;
+          }
+          
           if (item.length > 3) {
             products.push({
               productName: item,


### PR DESCRIPTION
…grocery items

- Add filtering in server-side text fallback parsing to skip meal plan items
- Add filtering in client-side structured data processing to exclude meal descriptions
- Prevent items like "Breakfast: Greek yogurt with berries" from being parsed as cart items
- Ensure meal plan items display as recipes, not grocery products

🤖 Generated with [Claude Code](https://claude.ai/code)